### PR TITLE
Subscribe to list to fix route to 404 page for undefined list/id

### DIFF
--- a/src/app/main/albums/album-details/album-router-activator.service.ts
+++ b/src/app/main/albums/album-details/album-router-activator.service.ts
@@ -1,19 +1,37 @@
 import { Router, ActivatedRouteSnapshot, CanActivate } from '@angular/router';
 import { Injectable } from '@angular/core';
 import { AlbumDetailsService } from '../specific/album-details.service';
+import { AlbumContainer } from '../specific/album-container';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AlbumRouteActivator implements CanActivate {
+  list: AlbumContainer;
+
   constructor(private _albumDetailsService: AlbumDetailsService, private router: Router) {
 
   }
 
   canActivate(route: ActivatedRouteSnapshot) {
+    const albumExists = !!this._albumDetailsService.getAlbum(+route.params['id']).subscribe(response => {
+      this.list = response;
+      if (this.list === undefined) {
+        this.router.navigate(['/404']);
+        //console.log("404 - Does not exist");
+      }
+    });
+
+    return albumExists;
+
+
+    /* This doesn't work:
+
     const albumExists = !!this._albumDetailsService.getAlbum(+route.params['id']);
 
     if (!albumExists) this.router.navigate(['/404']);
       return albumExists;
+
+    */
   }
 }

--- a/src/app/main/albums/specific/album-details.service.ts
+++ b/src/app/main/albums/specific/album-details.service.ts
@@ -14,7 +14,10 @@ export class AlbumDetailsService {
 
   getAlbum(id: number): Observable<AlbumContainer> {
     return this._httpClient.get(this._albumUrl)
-    .pipe(map((response: AlbumContainer[]) => response.find(list => list.id === id)));
+    .pipe(map((response: AlbumContainer[]) => response.find(list =>
+      //{
+        list.id === id
+      //console.log(list.id, list.id === id, list);}
+      )));
   }
-
 }


### PR DESCRIPTION
**This pull request makes the following changes:**
- Fixes issue no #7 

**Approach adopted:**
- Checks when list is undefined and then navigate to 404 page.

(don't know if this is the best solution but works in this case)